### PR TITLE
Destination Folder Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Authorization is done by [oauth-v2](http://docs.oauthv2.apiary.io/) component.
 #### Parameters
 Configuration supports the following parameters
 - **`mode`** - describes how to resolve conflicts of destination file names. If set to `rewrite` then the conflicted file will be rewritten otherwise new file with sequence number appended to the name will be created e.g. _my file (1)_.
-- **`folder`** - destination folder name within the writer application folder e.g _mydata_
+- **`folder`** - destination folder name within the writer application folder e.g _mydata_. If folder does not exist it will be created.
 
 
 #### Sample configuration

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Use [Dropbox API v2](https://www.dropbox.com/developers/documentation/http/docum
 Authorization is done by [oauth-v2](http://docs.oauthv2.apiary.io/) component.
 
 #### Parameters
-Configuration supports parameter **`mode`** which describes how to resolve conflicts of destination file names. If set to `rewrite` then the conflicted file will be rewritten otherwise new file with sequence number appended to the name will be created e.g. _my file (1)_.
+Configuration supports the following parameters
+- **`mode`** - describes how to resolve conflicts of destination file names. If set to `rewrite` then the conflicted file will be rewritten otherwise new file with sequence number appended to the name will be created e.g. _my file (1)_.
+- **`folder`** - destination folder name within the writer application folder e.g _mydata_
 
 
 #### Sample configuration
@@ -32,7 +34,8 @@ Configuration supports parameter **`mode`** which describes how to resolve confl
     }
   },
   "parameters": {
-    "mode": "rewrite"
+    "mode": "rewrite",
+    "folder": "mydata"
   },
   "authorization": {
     "oauth_api": {

--- a/configurationSchema.json
+++ b/configurationSchema.json
@@ -2,9 +2,14 @@
   "type": "object",
   "title": "Upload Parameters",
   "required": [
-    "mode"
+    "mode",
+    "folder"
   ],
   "properties": {
+    "folder": {
+      "type": "string",
+      "title": "Destination folder name within the application folder"
+    },
     "mode": {
       "enum": [
         "rewrite",
@@ -12,7 +17,7 @@
       ],
       "type": "string",
       "title": "Resolve names conflict strategy",
-      "default": "always create new"
+      "default": "create new"
     }
   }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 docker pull quay.io/keboola/developer-portal-cli-v2:latest
 export REPOSITORY=`docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME=$KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD=$KBC_DEVELOPERPORTAL_PASSWORD quay.io/keboola/developer-portal-cli-v2:latest ecr:get-repository keboola keboola.wr-dropbox-v2`
 docker tag keboola/wr-dropbox-v2:latest $REPOSITORY:$TRAVIS_TAG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     tty: true
   dev:
     image: keboola/wr-dropbox-v2
+    build: .
     volumes:
       - ./src:/code/src
       - ./vendor:/code/vendor


### PR DESCRIPTION
FIXES #1 
Adds support of destination folder to upload target files/tables to. If folder does not exist then it will be created. The folder is specified by `folder` in parameters config section.